### PR TITLE
Support SciMLBase v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqOperatorSplitting"
 uuid = "760fc936-9fa0-4281-9c1a-468957eedc89"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Dennis Ogiermann <termi-official@users.noreply.github.com> and contributors"]
 
 [deps]
@@ -27,7 +27,7 @@ OrdinaryDiffEqTsit5 = "1.1.0"
 PrecompileTools = "1.0"
 RecursiveArrayTools = "3.39.0"
 SafeTestsets = "0.1.0"
-SciMLBase = "2.77.0"
+SciMLBase = "2.77.0, 3.1"
 TimerOutputs = "0.5.28"
 Unrolled = "0.1.5"
 julia = "1.10"

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -1115,3 +1115,11 @@ end
 
 DiffEqBase.u_modified!(i::OperatorSplittingIntegrator, bool) = i.u_modified = bool
 DiffEqBase.u_modified!(i::SplitSubIntegrator, bool) = i.u_modified = bool
+
+# SciMLBase v3 renamed `u_modified!` → `derivative_discontinuity!`. On v3+,
+# also provide the overloads under the new name so callers using the new
+# API dispatch correctly instead of hitting the generic `error(...)` fallback.
+@static if isdefined(SciMLBase, :derivative_discontinuity!)
+    SciMLBase.derivative_discontinuity!(i::OperatorSplittingIntegrator, bool) = i.u_modified = bool
+    SciMLBase.derivative_discontinuity!(i::SplitSubIntegrator, bool) = i.u_modified = bool
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,7 +74,13 @@ function forward_sync_internal!(u_source, child::DEIntegrator, solution_indices)
     @views usrc = u_source[solution_indices]
     sync_vectors!(child.u, usrc)
     sync_vectors!(child.uprev, child.u)
-    SciMLBase.u_modified!(child, true)
+    # SciMLBase v3 renamed this to `derivative_discontinuity!`; call the
+    # appropriate name based on which SciMLBase is loaded.
+    @static if isdefined(SciMLBase, :derivative_discontinuity!)
+        SciMLBase.derivative_discontinuity!(child, true)
+    else
+        SciMLBase.u_modified!(child, true)
+    end
     return nothing
 end
 


### PR DESCRIPTION
## Summary

Courtesy PR for the SciMLBase v3 release.

- Extend `SciMLBase` compat to `"2.77.0, 3.1"`.
- Bump version to 0.2.4.
- Add `SciMLBase.derivative_discontinuity!` overloads for `OperatorSplittingIntegrator` and `SplitSubIntegrator` in `src/integrator.jl` alongside the existing `DiffEqBase.u_modified!` methods, guarded by `@static if isdefined(SciMLBase, :derivative_discontinuity!)`.
- Update the `SciMLBase.u_modified!(child, true)` call in `forward_sync_internal!` (`src/utils.jl:77`) to dispatch to `derivative_discontinuity!` on v3+ via the same `isdefined` guard, so the call hits the direct method instead of the deprecated forward.

SciMLBase v3 renamed `u_modified!` → `derivative_discontinuity!` with an `@deprecate` shim on the old name. Existing overloads still dispatch for legacy callers, but callers that have migrated to the new name would otherwise hit the generic `error(...)` fallback. The `isdefined` guards keep the code compiling on both v2 and v3.

## Known limitation

Local tests cannot be run: `Pkg.resolve()` fails on any env containing SciMLBase 3.1 because `OrdinaryDiffEq` in the registry still pins `RecursiveArrayTools ≤ 3.54`. Expect CI to fail at the `Pkg.add` step until upstream bumps.

## Reference pattern

Same `@static if isdefined(SciMLBase, :derivative_discontinuity!)` shim used in SciML/DiffEqCallbacks.jl#300.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)