### PR TITLE
chore: bump version to v0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrdinaryDiffEqOperatorSplitting"
 uuid = "760fc936-9fa0-4281-9c1a-468957eedc89"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Dennis Ogiermann <termi-official@users.noreply.github.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

- Bumps `version` in `Project.toml` from `0.2.4` to `0.3.0` to cut a new release.

Release notes (will be posted to `@JuliaRegistrator` on the merge commit after this PR lands):

## Breaking changes

- Upgraded to SciMLBase v3. Downstream packages pinning SciMLBase v2 must update their compat bounds.
- `init()` function signatures/behavior changed. Downstream callers that construct integrators manually may need updates.

## Features

- Added Subintegrator Nodes for composing operator-splitting hierarchies (#56).
- Added a PrecompileTools workload to cut time-to-first-solve (#50).

## Bug fixes

- Hotfix for OrdinaryDiffEqCore integration regression (#59).

## Refactoring & tooling

- Switched code formatting from JuliaFormatter to Runic.jl (#48).
- Removed `@unpack` usage in favor of destructuring (#49).
- Tightened explicit imports hygiene (#44).
- Migrated CompatHelper → Dependabot (#38).

## Documentation

- Fixed documentation typos and build warnings (#42, #43).

## Dependencies

- Broadened OrdinaryDiffEqCore compat to `1.19.0, 2, 3.1`.
- Bumped GitHub Actions: `actions/checkout` → 6, `codecov/codecov-action` → 6, `julia-actions/cache` → 3.