### PR TITLE
Add inner_dts keyword for multirate operator splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@
   for multirate operator splitting without having to mutate
   `integrator.child_subintegrators[i].dt` post-`init`. Backward compatible:
   omitting `inner_dts` broadcasts the outer `dt` to every child (the
-  pre-existing single-rate behavior). See the README for an example.
+  pre-existing single-rate behavior). See the usage docs for an example.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- `inner_dts` keyword argument to `init`, `solve`, and `reinit!` on
+  `OperatorSplittingProblem`. Configures per-child sub-integrator step sizes
+  for multirate operator splitting without having to mutate
+  `integrator.child_subintegrators[i].dt` post-`init`. Backward compatible:
+  omitting `inner_dts` broadcasts the outer `dt` to every child (the
+  pre-existing single-rate behavior). See the README for an example.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ using OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqOperatorSplitting
 function ode_true(du, u, p, t)
     du .-= 0.1u
     du[1] -= 0.01u[3]
-    du[3] -= 0.01u[1]
+    return du[3] -= 0.01u[1]
 end
 
 # This is the first operator of the ODE.
 function ode1(du, u, p, t)
-    @. du = -0.1u
+    return @. du = -0.1u
 end
 f1 = ODEFunction(ode1)
 f1dofs = [1, 2, 3]
@@ -46,7 +46,7 @@ f1dofs = [1, 2, 3]
 # This is the second operator of the ODE.
 function ode2(du, u, p, t)
     du[1] = -0.01u[2]
-    du[2] = -0.01u[1]
+    return du[2] = -0.01u[1]
 end
 f2 = ODEFunction(ode2)
 f2dofs = [1, 3]
@@ -75,41 +75,3 @@ end
 ## Available Solvers
 
 For the list of available solvers, please refer to the [OrdinaryDiffEqOperatorSplitting.jl Solvers](https://sciml.github.io/OrdinaryDiffEqOperatorSplitting.jl/dev/api-reference/#Solvers) pages.
-
-## Multirate splitting
-
-Operators with different stiffness or cost can use different substep sizes via
-the `inner_dts` keyword. Each entry sets the corresponding child sub-integrator's
-`dt` (or `nothing` to share the outer `dt`).
-
-```julia
-using OrdinaryDiffEqOperatorSplitting
-using OrdinaryDiffEqLowOrderRK              # Euler
-
-# Three-state toy system: y' = (A + B) y, where A is "fast" and B is "slow".
-function ode_A!(du, u, p, t)
-    du[1] = -0.1 * u[1]
-    du[2] = -0.1 * u[2]
-    du[3] = -0.1 * u[3]
-end
-function ode_B!(du, u, p, t)
-    du[1] = -0.01 * u[3]
-    du[3] = -0.01 * u[1]
-end
-fA = ODEFunction(ode_A!)
-fB = ODEFunction(ode_B!)
-fsplit = GenericSplitFunction((fA, fB), ([1, 2, 3], [1, 3]))
-prob   = OperatorSplittingProblem(fsplit, [1.0, 1.0, 1.0], (0.0, 10.0))
-
-dt_outer = 0.5            # Strang macro step (slow operator)
-dt_inner = 0.05           # fast operator substep
-
-sol = solve(prob, StrangMarchuk((Euler(), Euler()));
-            dt        = dt_outer,
-            inner_dts = (dt_inner, dt_outer),
-            adaptive  = false)
-```
-
-The fast child takes `dt_outer / 2 / dt_inner = 5` substeps inside each Strang
-half-step; the slow child takes one Euler step per outer `dt_outer`. The same
-kwarg works on `reinit!`: pass it again to preserve the multirate configuration.

--- a/README.md
+++ b/README.md
@@ -75,3 +75,41 @@ end
 ## Available Solvers
 
 For the list of available solvers, please refer to the [OrdinaryDiffEqOperatorSplitting.jl Solvers](https://sciml.github.io/OrdinaryDiffEqOperatorSplitting.jl/dev/api-reference/#Solvers) pages.
+
+## Multirate splitting
+
+Operators with different stiffness or cost can use different substep sizes via
+the `inner_dts` keyword. Each entry sets the corresponding child sub-integrator's
+`dt` (or `nothing` to share the outer `dt`).
+
+```julia
+using OrdinaryDiffEqOperatorSplitting
+using OrdinaryDiffEqLowOrderRK              # Euler
+
+# Three-state toy system: y' = (A + B) y, where A is "fast" and B is "slow".
+function ode_A!(du, u, p, t)
+    du[1] = -0.1 * u[1]
+    du[2] = -0.1 * u[2]
+    du[3] = -0.1 * u[3]
+end
+function ode_B!(du, u, p, t)
+    du[1] = -0.01 * u[3]
+    du[3] = -0.01 * u[1]
+end
+fA = ODEFunction(ode_A!)
+fB = ODEFunction(ode_B!)
+fsplit = GenericSplitFunction((fA, fB), ([1, 2, 3], [1, 3]))
+prob   = OperatorSplittingProblem(fsplit, [1.0, 1.0, 1.0], (0.0, 10.0))
+
+dt_outer = 0.5            # Strang macro step (slow operator)
+dt_inner = 0.05           # fast operator substep
+
+sol = solve(prob, StrangMarchuk((Euler(), Euler()));
+            dt        = dt_outer,
+            inner_dts = (dt_inner, dt_outer),
+            adaptive  = false)
+```
+
+The fast child takes `dt_outer / 2 / dt_inner = 5` substeps inside each Strang
+half-step; the slow child takes one Euler step per outer `dt_outer`. The same
+kwarg works on `reinit!`: pass it again to preserve the multirate configuration.

--- a/docs/src/usage/index.md
+++ b/docs/src/usage/index.md
@@ -11,12 +11,12 @@ using OrdinaryDiffEqLowOrderRK, OrdinaryDiffEqOperatorSplitting
 function ode_true(du, u, p, t)
     du .-= 0.1u
     du[1] -= 0.01u[3]
-    du[3] -= 0.01u[1]
+    return du[3] -= 0.01u[1]
 end
 
 # This is the first operator of the ODE.
 function ode1(du, u, p, t)
-    @. du = -0.1u
+    return @. du = -0.1u
 end
 f1 = ODEFunction(ode1)
 f1dofs = [1, 2, 3]
@@ -24,7 +24,7 @@ f1dofs = [1, 2, 3]
 # This is the second operator of the ODE.
 function ode2(du, u, p, t)
     du[1] = -0.01u[2]
-    du[2] = -0.01u[1]
+    return du[2] = -0.01u[1]
 end
 f2 = ODEFunction(ode2)
 f2dofs = [1, 3]
@@ -64,3 +64,35 @@ for (u, t) in TimeChoiceIterator(integrator, 0.0:0.5:1.0)
     @show t, u
 end
 ```
+
+## Multirate splitting
+
+Operators with different stiffness or cost can use different substep sizes via
+the `inner_dts` keyword on `init`, `solve`, and `reinit!`. Each entry sets the
+corresponding child sub-integrator's `dt`; `nothing` at an index falls back to
+the outer `dt`.
+
+```julia
+# Reuse f, prob from the minimal example above. Suppose ode1 is cheap but
+# CFL-limited at a small dt, while ode2 is stable at a large dt.
+alg = StrangMarchuk((Euler(), Euler()))
+
+dt_outer = 0.1
+dt_inner = 0.02       # ode1 subcycles 5 substeps per outer Strang half-step
+
+sol = solve(
+    prob, alg;
+    dt = dt_outer,
+    inner_dts = (dt_inner, dt_outer),
+    adaptive = false,
+)
+```
+
+Default `inner_dts = nothing` preserves the existing single-rate behaviour (the
+outer `dt` is broadcast to every child). A `Tuple` activates multirate. For
+non-adaptive inner algorithms the entry becomes the fixed substep size; for
+adaptive inner algorithms (e.g. `Tsit5`) it acts as a starting hint via
+`set_proposed_dt!`. The same kwarg works on `reinit!`: re-pass the Tuple to
+preserve the multirate configuration. Nested split children (a
+`GenericSplitFunction` as a child) are explicitly rejected with a clear
+`ArgumentError`.

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -185,29 +185,41 @@ const AnySplitIntegrator = Union{SplitSubIntegrator, OperatorSplittingIntegrator
 # ---------------------------------------------------------------------------
 function _validate_inner_dts(inner_dts, f::AbstractOperatorSplitFunction)
     inner_dts === nothing && return nothing
-    inner_dts isa Tuple || throw(ArgumentError(
-        "inner_dts must be a Tuple or nothing, got $(typeof(inner_dts))"))
+    inner_dts isa Tuple || throw(
+        ArgumentError(
+            "inner_dts must be a Tuple or nothing, got $(typeof(inner_dts))"
+        )
+    )
     n = num_operators(f)
-    length(inner_dts) == n || throw(ArgumentError(
-        "inner_dts has length $(length(inner_dts)), expected $n " *
-        "(= num_operators of the split problem)"))
+    length(inner_dts) == n || throw(
+        ArgumentError(
+            "inner_dts has length $(length(inner_dts)), expected $n " *
+                "(= num_operators of the split problem)"
+        )
+    )
     for (i, d) in enumerate(inner_dts)
         d === nothing && continue
-        (d isa Number && isfinite(d) && d > zero(d)) || throw(ArgumentError(
-            "inner_dts[$i] must be a finite positive Number or nothing, got $d"))
+        (d isa Number && isfinite(d) && d > zero(d)) || throw(
+            ArgumentError(
+                "inner_dts[$i] must be a finite positive Number or nothing, got $d"
+            )
+        )
         op_i = get_operator(f, i)
         if op_i isa AbstractOperatorSplitFunction
-            throw(ArgumentError(
-                "inner_dts[$i] given for a nested operator-splitting child; " *
-                "nested multirate is not yet supported. Pass nothing for that " *
-                "index, or flatten the split."))
+            throw(
+                ArgumentError(
+                    "inner_dts[$i] given for a nested operator-splitting child; " *
+                        "nested multirate is not yet supported. Pass nothing for that " *
+                        "index, or flatten the split."
+                )
+            )
         end
     end
     return nothing
 end
 
 @inline _resolve_child_dt(::Nothing, _i, dt_outer) = dt_outer
-@inline _resolve_child_dt(t::Tuple, i, dt_outer)   =
+@inline _resolve_child_dt(t::Tuple, i, dt_outer) =
     t[i] === nothing ? dt_outer : t[i]
 
 # ---------------------------------------------------------------------------
@@ -252,38 +264,6 @@ end
 # ---------------------------------------------------------------------------
 # __init
 # ---------------------------------------------------------------------------
-"""
-    init(prob::OperatorSplittingProblem, alg; dt, inner_dts = nothing, kwargs...)
-
-Initialise an operator-splitting integrator.
-
-`dt` is the outer macro step (the Lie / Strang sandwich step).
-
-`inner_dts::Union{Nothing, Tuple}` configures multirate splitting:
-
-- `nothing` (default): every sub-integrator uses the outer `dt` (single-rate).
-- `Tuple` of length `num_operators(prob.f)`: each entry sets the corresponding
-  child sub-integrator's `dt`. `nothing` at index `i` falls back to the outer `dt`.
-
-For non-adaptive inner algorithms (e.g. `Euler`, `SSPRK33`) the entry becomes the
-fixed substep size: the child subcycles until reaching the parent's requested
-advance. For adaptive inner algorithms (e.g. `Tsit5`) the entry is a starting
-hint via `set_proposed_dt!`; the adaptive controller takes over after the first
-step.
-
-Nested operator splittings (a child that is itself a `GenericSplitFunction`)
-are not supported in `inner_dts` yet: pass `nothing` for that index or flatten
-the split.
-
-# Example
-
-```julia
-sol = solve(prob, StrangMarchuk((SSPRK33(), Euler()));
-            dt        = 0.01,
-            inner_dts = (0.001, 0.01),
-            adaptive  = false)
-```
-"""
 function SciMLBase.__init(
         prob::OperatorSplittingProblem,
         alg::AbstractOperatorSplittingAlgorithm,
@@ -391,19 +371,6 @@ end
 # ---------------------------------------------------------------------------
 SciMLBase.has_reinit(integrator::OperatorSplittingIntegrator) = true
 
-"""
-    reinit!(integrator::OperatorSplittingIntegrator, u0 = integrator.sol.prob.u0;
-            t0, tf, dt, inner_dts = nothing, kwargs...)
-
-Re-initialise the integrator for another solve over `[t0, tf]`.
-
-`inner_dts` has the same semantics as in `init`:
-
-- `nothing` (default) or omitted: the outer `dt` is broadcast to every child
-  sub-integrator (matching the pre-multirate behavior).
-- `Tuple`: per-child override. To preserve a multirate configuration from
-  `init` across reinit, re-pass the same Tuple here.
-"""
 function DiffEqBase.reinit!(
         integrator::OperatorSplittingIntegrator,
         u0 = integrator.sol.prob.u0;

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -181,8 +181,109 @@ end
 const AnySplitIntegrator = Union{SplitSubIntegrator, OperatorSplittingIntegrator}
 
 # ---------------------------------------------------------------------------
+# inner_dts: per-child sub-integrator step sizes for multirate splitting
+# ---------------------------------------------------------------------------
+function _validate_inner_dts(inner_dts, f::AbstractOperatorSplitFunction)
+    inner_dts === nothing && return nothing
+    inner_dts isa Tuple || throw(ArgumentError(
+        "inner_dts must be a Tuple or nothing, got $(typeof(inner_dts))"))
+    n = num_operators(f)
+    length(inner_dts) == n || throw(ArgumentError(
+        "inner_dts has length $(length(inner_dts)), expected $n " *
+        "(= num_operators of the split problem)"))
+    for (i, d) in enumerate(inner_dts)
+        d === nothing && continue
+        (d isa Number && isfinite(d) && d > zero(d)) || throw(ArgumentError(
+            "inner_dts[$i] must be a finite positive Number or nothing, got $d"))
+        op_i = get_operator(f, i)
+        if op_i isa AbstractOperatorSplitFunction
+            throw(ArgumentError(
+                "inner_dts[$i] given for a nested operator-splitting child; " *
+                "nested multirate is not yet supported. Pass nothing for that " *
+                "index, or flatten the split."))
+        end
+    end
+    return nothing
+end
+
+@inline _resolve_child_dt(::Nothing, _i, dt_outer) = dt_outer
+@inline _resolve_child_dt(t::Tuple, i, dt_outer)   =
+    t[i] === nothing ? dt_outer : t[i]
+
+# ---------------------------------------------------------------------------
+# DiffEqBase.solve override: same rationale as the init override below it.
+# Bypass SciMLBase.checkkwargs so that package-specific kwargs (e.g.
+# inner_dts) reach __solve without being rejected as unrecognised.
+# ---------------------------------------------------------------------------
+function DiffEqBase.solve(
+        prob::OperatorSplittingProblem,
+        alg::AbstractOperatorSplittingAlgorithm,
+        args...;
+        sensealg = nothing,
+        u0 = nothing,
+        p = nothing,
+        kwargs...
+    )
+    merged = DiffEqBase.has_kwargs(prob) && !isempty(prob.kwargs) ?
+        merge(values(prob.kwargs), kwargs) : kwargs
+    return SciMLBase.__solve(prob, alg, args...; merged...)
+end
+
+# ---------------------------------------------------------------------------
+# DiffEqBase.init override: bypass SciMLBase.checkkwargs so that
+# package-specific kwargs (e.g. inner_dts) reach __init without being
+# rejected as unrecognised. Problem-level kwargs are merged with caller
+# kwargs here (caller wins on conflict), mirroring DiffEqBase.init_call.
+# ---------------------------------------------------------------------------
+function DiffEqBase.init(
+        prob::OperatorSplittingProblem,
+        alg::AbstractOperatorSplittingAlgorithm,
+        args...;
+        sensealg = nothing,
+        u0 = nothing,
+        p = nothing,
+        kwargs...
+    )
+    merged = DiffEqBase.has_kwargs(prob) && !isempty(prob.kwargs) ?
+        merge(values(prob.kwargs), kwargs) : kwargs
+    return SciMLBase.__init(prob, alg, args...; merged...)
+end
+
+# ---------------------------------------------------------------------------
 # __init
 # ---------------------------------------------------------------------------
+"""
+    init(prob::OperatorSplittingProblem, alg; dt, inner_dts = nothing, kwargs...)
+
+Initialise an operator-splitting integrator.
+
+`dt` is the outer macro step (the Lie / Strang sandwich step).
+
+`inner_dts::Union{Nothing, Tuple}` configures multirate splitting:
+
+- `nothing` (default): every sub-integrator uses the outer `dt` (single-rate).
+- `Tuple` of length `num_operators(prob.f)`: each entry sets the corresponding
+  child sub-integrator's `dt`. `nothing` at index `i` falls back to the outer `dt`.
+
+For non-adaptive inner algorithms (e.g. `Euler`, `SSPRK33`) the entry becomes the
+fixed substep size: the child subcycles until reaching the parent's requested
+advance. For adaptive inner algorithms (e.g. `Tsit5`) the entry is a starting
+hint via `set_proposed_dt!`; the adaptive controller takes over after the first
+step.
+
+Nested operator splittings (a child that is itself a `GenericSplitFunction`)
+are not supported in `inner_dts` yet: pass `nothing` for that index or flatten
+the split.
+
+# Example
+
+```julia
+sol = solve(prob, StrangMarchuk((SSPRK33(), Euler()));
+            dt        = 0.01,
+            inner_dts = (0.001, 0.01),
+            adaptive  = false)
+```
+"""
 function SciMLBase.__init(
         prob::OperatorSplittingProblem,
         alg::AbstractOperatorSplittingAlgorithm,
@@ -199,12 +300,14 @@ function SciMLBase.__init(
         # controller = OrdinaryDiffEqCore.PIController(0.14, 0.08),
         alias_u0 = false,
         verbose = true,
+        inner_dts = nothing,
         kwargs...
     )
     (; u0, p) = prob
     t0, tf = prob.tspan
 
     dt > zero(dt) || error("dt must be positive")
+    _validate_inner_dts(inner_dts, prob.f)
     dtcache = dt
     dt = tf > t0 ? dt : -dt
     tType = typeof(dt)
@@ -244,7 +347,8 @@ function SciMLBase.__init(
         1:length(u),
         t0, dt, tf,
         tstops, saveat, d_discontinuities, callback,
-        adaptive, verbose
+        adaptive, verbose,
+        inner_dts,
     )
 
     cache = init_cache(
@@ -287,6 +391,19 @@ end
 # ---------------------------------------------------------------------------
 SciMLBase.has_reinit(integrator::OperatorSplittingIntegrator) = true
 
+"""
+    reinit!(integrator::OperatorSplittingIntegrator, u0 = integrator.sol.prob.u0;
+            t0, tf, dt, inner_dts = nothing, kwargs...)
+
+Re-initialise the integrator for another solve over `[t0, tf]`.
+
+`inner_dts` has the same semantics as in `init`:
+
+- `nothing` (default) or omitted: the outer `dt` is broadcast to every child
+  sub-integrator (matching the pre-multirate behavior).
+- `Tuple`: per-child override. To preserve a multirate configuration from
+  `init` across reinit, re-pass the same Tuple here.
+"""
 function DiffEqBase.reinit!(
         integrator::OperatorSplittingIntegrator,
         u0 = integrator.sol.prob.u0;
@@ -297,8 +414,13 @@ function DiffEqBase.reinit!(
         tstops = integrator._tstops,
         saveat = integrator._saveat,
         reinit_callbacks = true,
-        reinit_retcode = true
+        reinit_retcode = true,
+        inner_dts = nothing,
     )
+    if inner_dts !== nothing
+        _validate_inner_dts(inner_dts, integrator.f)
+    end
+
     integrator.u .= u0
     integrator.uprev .= u0
     integrator.t = t0
@@ -331,25 +453,33 @@ function DiffEqBase.reinit!(
         integrator.child_subintegrators;
         t0, tf, dt,
         erase_sol, tstops, saveat,
-        reinit_callbacks, reinit_retcode
+        reinit_callbacks, reinit_retcode,
+        inner_dts,
     )
     return nothing
 end
 
 # --- subreinit! helpers ---
 
-# Iterate over a tuple of children (outermost call from reinit!)
+# Iterate over a tuple of children and reinit each with its resolved dt.
 @unroll function _subreinit_tuple!(
         f,
         u0,
         children::Tuple;
+        dt,
+        inner_dts = nothing,
         kwargs...
     )
     i = 1
     @unroll for child in children
-        _subreinit_child!(get_operator(f, i), u0, child; kwargs...)
+        _subreinit_child!(
+            get_operator(f, i), u0, child;
+            dt = _resolve_child_dt(inner_dts, i, dt),
+            kwargs...,
+        )
         i += 1
     end
+    return nothing
 end
 
 # Reinitialise a leaf DEIntegrator child
@@ -937,7 +1067,8 @@ function build_subintegrators(
         solution_indices,
         t0, dt, tf,
         tstops, saveat, d_discontinuities, callback,
-        adaptive, verbose
+        adaptive, verbose,
+        inner_dts = nothing,
     )
     (; f, p) = prob
 
@@ -949,7 +1080,7 @@ function build_subintegrators(
             p[i],
             uprevouter, uouter, u_master,
             f.solution_indices[i],
-            t0, dt, tf,
+            t0, _resolve_child_dt(inner_dts, i, dt), tf,
             tstops, saveat, d_discontinuities, callback,
             adaptive, verbose
         ),

--- a/test/operator_splitting_api.jl
+++ b/test/operator_splitting_api.jl
@@ -399,3 +399,193 @@ _sub1_iter_factor(alg::FakeAdaptiveAlgorithm) = _sub1_iter_factor(alg.alg)
         end
     end
 end
+
+@testset "inner_dts validation" begin
+    f1dofs = [1, 2, 3]
+    f2dofs = [1, 3]
+    fsplit = GenericSplitFunction((f1, f2), (f1dofs, f2dofs))
+    prob   = OperatorSplittingProblem(fsplit, u0, tspan)
+    alg    = StrangMarchuk((Euler(), Euler()))
+
+    # Wrong length.
+    @test_throws ArgumentError DiffEqBase.init(
+        prob, alg; dt = 0.1, inner_dts = (0.01,),
+        adaptive = false, alias_u0 = false,
+    )
+
+    # Non-Tuple input.
+    @test_throws ArgumentError DiffEqBase.init(
+        prob, alg; dt = 0.1, inner_dts = [0.01, 0.1],
+        adaptive = false, alias_u0 = false,
+    )
+
+    # Negative entry.
+    @test_throws ArgumentError DiffEqBase.init(
+        prob, alg; dt = 0.1, inner_dts = (-1.0, 0.1),
+        adaptive = false, alias_u0 = false,
+    )
+
+    # Zero entry.
+    @test_throws ArgumentError DiffEqBase.init(
+        prob, alg; dt = 0.1, inner_dts = (0.0, 0.1),
+        adaptive = false, alias_u0 = false,
+    )
+
+    # Inf entry.
+    @test_throws ArgumentError DiffEqBase.init(
+        prob, alg; dt = 0.1, inner_dts = (Inf, 0.1),
+        adaptive = false, alias_u0 = false,
+    )
+
+    # `nothing` and positive Numbers are accepted (no throw).
+    integrator = DiffEqBase.init(
+        prob, alg; dt = 0.1, inner_dts = (0.01, nothing),
+        adaptive = false, alias_u0 = false,
+    )
+    @test integrator isa OS.OperatorSplittingIntegrator
+end
+
+@testset "inner_dts rejects nested split children" begin
+    f1dofs = [1, 2, 3]
+    f2dofs = [1, 3]
+    f3dofs = [1, 2]
+    fsplit_inner = GenericSplitFunction((f3, f3), (f3dofs, f3dofs))
+    fsplit_outer = GenericSplitFunction((f1, fsplit_inner), (f1dofs, f2dofs))
+    prob   = OperatorSplittingProblem(fsplit_outer, u0, tspan)
+    alg    = StrangMarchuk((Euler(), StrangMarchuk((Euler(), Euler()))))
+
+    @test_throws ArgumentError DiffEqBase.init(
+        prob, alg; dt = 0.1, inner_dts = (0.01, 0.01),
+        adaptive = false, alias_u0 = false,
+    )
+
+    # Passing `nothing` for the nested child is allowed.
+    integrator = DiffEqBase.init(
+        prob, alg; dt = 0.1, inner_dts = (0.01, nothing),
+        adaptive = false, alias_u0 = false,
+    )
+    @test integrator isa OS.OperatorSplittingIntegrator
+end
+
+@testset "inner_dts multirate iter counts" begin
+    # Use a local tspan and exact-rational dt so that half_dt / dt_child is
+    # always an integer and tstop arithmetic is exact. This avoids floating-point
+    # tstop accumulation in the leaf ODE integrator over many outer steps.
+    local_tspan = (0.0, 1.0)
+    dt = 0.25         # nsteps = 4
+    R  = 4            # dt_child = dt/R = 0.0625; half_dt/dt_child = 2 exactly
+    f1dofs = [1, 2, 3]
+    f2dofs = [1, 3]
+    fsplit = GenericSplitFunction((f1, f2), (f1dofs, f2dofs))
+    prob   = OperatorSplittingProblem(fsplit, u0, local_tspan)
+    alg    = StrangMarchuk((Euler(), Euler()))
+
+    integrator = DiffEqBase.init(
+        prob, alg;
+        dt = dt, inner_dts = (dt / R, dt),
+        adaptive = false, alias_u0 = false, verbose = false,
+    )
+    sub1 = integrator.child_subintegrators[1]
+    sub2 = integrator.child_subintegrators[2]
+    @test sub1.dt ≈ dt / R
+    @test sub2.dt ≈ dt
+
+    nsteps = round(Int, (local_tspan[2] - local_tspan[1]) / dt)
+    DiffEqBase.solve!(integrator)
+
+    # StrangMarchuk calls child 1 twice per outer step (forward + reverse half).
+    # With child-1 dt = dt/R, each half advances R/2 substeps exactly, total R per outer step.
+    @test sub1.iter == R * nsteps
+    @test sub2.iter == nsteps
+    @test integrator.t ≈ local_tspan[2]
+
+    # Compare against the unsplit reference solution at local_tspan[2].
+    trueu_local = exp((local_tspan[2] - local_tspan[1]) * (trueA + trueB)) * u0
+    @test isapprox(integrator.u, trueu_local, atol = 1.0e-3)
+end
+
+@testset "inner_dts as adaptive hint" begin
+    f1dofs = [1, 2, 3]
+    f2dofs = [1, 3]
+    fsplit = GenericSplitFunction((f1, f2), (f1dofs, f2dofs))
+    prob   = OperatorSplittingProblem(fsplit, u0, tspan)
+    alg    = StrangMarchuk((Tsit5(), Euler()))
+
+    integrator = DiffEqBase.init(
+        prob, alg;
+        dt = 0.1, inner_dts = (1.0e-3, 0.1),
+        adaptive = false, alias_u0 = false, verbose = false,
+    )
+    sub1 = integrator.child_subintegrators[1]
+
+    # Tsit5 is adaptive: inner_dts[1] is set as the starting hint.
+    @test sub1.dt ≈ 1.0e-3
+end
+
+@testset "inner_dts reinit semantics" begin
+    f1dofs = [1, 2, 3]
+    f2dofs = [1, 3]
+    fsplit = GenericSplitFunction((f1, f2), (f1dofs, f2dofs))
+    prob   = OperatorSplittingProblem(fsplit, u0, tspan)
+    alg    = StrangMarchuk((Euler(), Euler()))
+
+    integrator = DiffEqBase.init(
+        prob, alg;
+        dt = 0.1, inner_dts = (0.025, 0.1),
+        adaptive = false, alias_u0 = false, verbose = false,
+    )
+    sub1 = integrator.child_subintegrators[1]
+    sub2 = integrator.child_subintegrators[2]
+    @test sub1.dt ≈ 0.025
+    @test sub2.dt ≈ 0.1
+
+    # Case 1: omit inner_dts. Outer dt broadcasts to all children (existing behavior).
+    DiffEqBase.reinit!(integrator, u0; tf = tspan[2], dt = 0.2)
+    @test sub1.dt ≈ 0.2
+    @test sub2.dt ≈ 0.2
+
+    # Case 2: re-pass inner_dts to preserve multirate configuration.
+    DiffEqBase.reinit!(
+        integrator, u0;
+        tf = tspan[2], dt = 0.2, inner_dts = (0.025, 0.2),
+    )
+    @test sub1.dt ≈ 0.025
+    @test sub2.dt ≈ 0.2
+
+    # Case 3: per-child override with nothing entry (entry-level fallback).
+    DiffEqBase.reinit!(
+        integrator, u0;
+        tf = tspan[2], dt = 0.2, inner_dts = (0.01, nothing),
+    )
+    @test sub1.dt ≈ 0.01
+    @test sub2.dt ≈ 0.2
+end
+
+@testset "inner_dts via DiffEqBase.solve" begin
+    local_tspan = (0.0, 1.0)
+    dt = 0.25
+    R  = 4
+    f1dofs = [1, 2, 3]
+    f2dofs = [1, 3]
+    fsplit = GenericSplitFunction((f1, f2), (f1dofs, f2dofs))
+    prob   = OperatorSplittingProblem(fsplit, u0, local_tspan)
+    alg    = StrangMarchuk((Euler(), Euler()))
+
+    sol = DiffEqBase.solve(
+        prob, alg;
+        dt = dt, inner_dts = (dt / R, dt),
+        adaptive = false, alias_u0 = false, verbose = false,
+    )
+    @test sol.retcode == ReturnCode.Success
+    @test sol.prob.tspan[2] ≈ local_tspan[2]
+
+    # Verify accuracy by replaying the same setup via init + solve!.
+    integrator2 = DiffEqBase.init(
+        prob, alg;
+        dt = dt, inner_dts = (dt / R, dt),
+        adaptive = false, alias_u0 = false, verbose = false,
+    )
+    DiffEqBase.solve!(integrator2)
+    trueu_local = exp((local_tspan[2] - local_tspan[1]) * (trueA + trueB)) * u0
+    @test isapprox(integrator2.u, trueu_local, atol = 1.0e-3)
+end

--- a/test/operator_splitting_api.jl
+++ b/test/operator_splitting_api.jl
@@ -404,8 +404,8 @@ end
     f1dofs = [1, 2, 3]
     f2dofs = [1, 3]
     fsplit = GenericSplitFunction((f1, f2), (f1dofs, f2dofs))
-    prob   = OperatorSplittingProblem(fsplit, u0, tspan)
-    alg    = StrangMarchuk((Euler(), Euler()))
+    prob = OperatorSplittingProblem(fsplit, u0, tspan)
+    alg = StrangMarchuk((Euler(), Euler()))
 
     # Wrong length.
     @test_throws ArgumentError DiffEqBase.init(
@@ -451,8 +451,8 @@ end
     f3dofs = [1, 2]
     fsplit_inner = GenericSplitFunction((f3, f3), (f3dofs, f3dofs))
     fsplit_outer = GenericSplitFunction((f1, fsplit_inner), (f1dofs, f2dofs))
-    prob   = OperatorSplittingProblem(fsplit_outer, u0, tspan)
-    alg    = StrangMarchuk((Euler(), StrangMarchuk((Euler(), Euler()))))
+    prob = OperatorSplittingProblem(fsplit_outer, u0, tspan)
+    alg = StrangMarchuk((Euler(), StrangMarchuk((Euler(), Euler()))))
 
     @test_throws ArgumentError DiffEqBase.init(
         prob, alg; dt = 0.1, inner_dts = (0.01, 0.01),
@@ -473,12 +473,12 @@ end
     # tstop accumulation in the leaf ODE integrator over many outer steps.
     local_tspan = (0.0, 1.0)
     dt = 0.25         # nsteps = 4
-    R  = 4            # dt_child = dt/R = 0.0625; half_dt/dt_child = 2 exactly
+    R = 4            # dt_child = dt/R = 0.0625; half_dt/dt_child = 2 exactly
     f1dofs = [1, 2, 3]
     f2dofs = [1, 3]
     fsplit = GenericSplitFunction((f1, f2), (f1dofs, f2dofs))
-    prob   = OperatorSplittingProblem(fsplit, u0, local_tspan)
-    alg    = StrangMarchuk((Euler(), Euler()))
+    prob = OperatorSplittingProblem(fsplit, u0, local_tspan)
+    alg = StrangMarchuk((Euler(), Euler()))
 
     integrator = DiffEqBase.init(
         prob, alg;
@@ -508,8 +508,8 @@ end
     f1dofs = [1, 2, 3]
     f2dofs = [1, 3]
     fsplit = GenericSplitFunction((f1, f2), (f1dofs, f2dofs))
-    prob   = OperatorSplittingProblem(fsplit, u0, tspan)
-    alg    = StrangMarchuk((Tsit5(), Euler()))
+    prob = OperatorSplittingProblem(fsplit, u0, tspan)
+    alg = StrangMarchuk((Tsit5(), Euler()))
 
     integrator = DiffEqBase.init(
         prob, alg;
@@ -526,8 +526,8 @@ end
     f1dofs = [1, 2, 3]
     f2dofs = [1, 3]
     fsplit = GenericSplitFunction((f1, f2), (f1dofs, f2dofs))
-    prob   = OperatorSplittingProblem(fsplit, u0, tspan)
-    alg    = StrangMarchuk((Euler(), Euler()))
+    prob = OperatorSplittingProblem(fsplit, u0, tspan)
+    alg = StrangMarchuk((Euler(), Euler()))
 
     integrator = DiffEqBase.init(
         prob, alg;
@@ -564,12 +564,12 @@ end
 @testset "inner_dts via DiffEqBase.solve" begin
     local_tspan = (0.0, 1.0)
     dt = 0.25
-    R  = 4
+    R = 4
     f1dofs = [1, 2, 3]
     f2dofs = [1, 3]
     fsplit = GenericSplitFunction((f1, f2), (f1dofs, f2dofs))
-    prob   = OperatorSplittingProblem(fsplit, u0, local_tspan)
-    alg    = StrangMarchuk((Euler(), Euler()))
+    prob = OperatorSplittingProblem(fsplit, u0, local_tspan)
+    alg = StrangMarchuk((Euler(), Euler()))
 
     sol = DiffEqBase.solve(
         prob, alg;


### PR DESCRIPTION
`OperatorSplittingProblem` propagates a single `dt` to every child sub-integrator. For multirate cases (one operator CFL-limited at small `dt`, another stable but expensive at large `dt`), the only way to configure per-child step sizes today is to reach into `integrator.child_subintegrators[i].dt` after `init`. This PR exposes per-child `dt` as a first-class kwarg.

Today:

```julia
integrator = init(prob, StrangMarchuk((SSPRK33(), Euler()));
                  dt = dt_coll, adaptive = false)
transport_child = integrator.child_subintegrators[1]
set_proposed_dt!(transport_child, dt_trans)
transport_child.dt = dt_trans
solve!(integrator)
```

With this PR:

```julia
sol = solve(prob, StrangMarchuk((SSPRK33(), Euler()));
            dt        = dt_coll,
            inner_dts = (dt_trans, dt_coll),
            adaptive  = false)
```

`inner_dts` is `Union{Nothing, Tuple}`. Default `nothing` keeps the single-rate behavior (backward compatible). A `Tuple` sets per-child dt; a `nothing` entry falls back to the outer dt. Same kwarg works on `reinit!` (re-pass to preserve multirate). For adaptive inner algorithms it's a starting hint via `set_proposed_dt!`. Nested splits are rejected with a clear `ArgumentError`.