### PR TITLE
Remove enable-beta-ecosystems flag (Julia no longer beta in Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
-enable-beta-ecosystems: true # Julia ecosystem
 updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests


### PR DESCRIPTION
Julia is now a generally available Dependabot ecosystem (there are currently no beta ecosystems), so the `enable-beta-ecosystems: true` flag is obsolete. This removes that single line from `.github/dependabot.yml`.