### PR TITLE
Canonicalize QA tests to @safetestset for module isolation

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrdinaryDiffEqOperatorSplitting = "760fc936-9fa0-4281-9c1a-468957eedc89"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -10,5 +11,6 @@ OrdinaryDiffEqOperatorSplitting = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,13 +1,16 @@
-using OrdinaryDiffEqOperatorSplitting
-using Aqua
-using JET
-using Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using OrdinaryDiffEqOperatorSplitting
+    using Aqua
+    using Test
     Aqua.test_all(OrdinaryDiffEqOperatorSplitting)
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using OrdinaryDiffEqOperatorSplitting
+    using JET
+    using Test
     # JET.test_package reports 2 possible errors in src/integrator.jl
     # (rollback_children!/_rollback_children! on the SplitSubIntegrator path).
     # Tracked in https://github.com/SciML/OrdinaryDiffEqOperatorSplitting.jl/issues/87


### PR DESCRIPTION
## What

The Core suite (`test/runtests.jl`) was already canonical — every independent unit is `@safetestset "X" include("x.jl")`. The only remaining plain `@testset` units were the two QA units in `test/qa/qa.jl` (Aqua, JET). This PR converts them to `@safetestset` so they each run in their own module, matching the rest of the suite. Behavior-preserving.

- `@testset "Aqua"` / `@testset "JET"` → `@safetestset`, each carrying its own `using` lines (Aqua unit: `OrdinaryDiffEqOperatorSplitting`, `Aqua`, `Test`; JET unit: `OrdinaryDiffEqOperatorSplitting`, `JET`, `Test`). Both bodies use only function calls / `@test_broken` (no package macros), so inline `@safetestset` bodies are safe. The JET `@test_broken` (tracking #87) is preserved verbatim.
- Added `SafeTestsets` (uuid `1bc83da4-3b8d-516f-aca4-4fe02f6d838f`) to `test/qa/Project.toml` `[deps]` + `[compat] SafeTestsets = "0.1, 1"` (the QA env activates its own project). The main `Project.toml` already carried `SafeTestsets`.

The GROUP-dispatch ladder, run path, and assertions are unchanged.

## Verification

Ran locally on Julia 1.11: `GROUP=QA Pkg.test()` passes — Quality Assurance: 11 Pass, 1 Broken, 12 Total (the 1 Broken is the pre-existing JET `@test_broken` for #87).

Ignore until reviewed by @ChrisRackauckas.